### PR TITLE
Fix hardcoded home directory path in assets.nix

### DIFF
--- a/home/assets.nix
+++ b/home/assets.nix
@@ -4,9 +4,8 @@ let
   inherit (config.lib.file) mkOutOfStoreSymlink;
 
   # Local nixpkgs working directory
-  # FIXME: Find a way to access the home directory without hardcoding it
-  # Because we will need it once we want to serve WSL system
-  nixConfigDirectory = "/Users/elw/Code/GitHub/elijah/nix-home";
+  # Use dynamic home directory path for better portability across systems
+  nixConfigDirectory = "${config.home.homeDirectory}/Code/GitHub/elijah/nix-home";
 in
 {
   # Symlink scripts directory altogether


### PR DESCRIPTION

# Fix hardcoded home directory path in assets.nix

## Summary

This PR addresses the hardcoded home directory path in `home/assets.nix` by replacing it with a dynamic path using `config.home.homeDirectory`. The change improves portability across different systems and resolves the FIXME comment about WSL compatibility.

**Key Changes:**
- Replaced hardcoded path `/Users/elw/Code/GitHub/elijah/nix-home` with dynamic `${config.home.homeDirectory}/Code/GitHub/elijah/nix-home`
- Removed FIXME comment about hardcoding home directory
- Maintains same functionality while improving cross-platform support

**Impact:** Improves configuration portability and resolves technical debt marked by FIXME comment.

## Review & Testing Checklist for Human

⚠️ **CRITICAL**: This change could not be tested locally due to nix not being available on the development system.

- [ ] **Verify config.home.homeDirectory exists**: Ensure this variable is available in your home-manager configuration
- [ ] **Test symlink functionality**: Verify that `~/scripts` and `~/.warp` symlinks still work correctly after the change
- [ ] **Verify path resolution**: Check that `${config.home.homeDirectory}/Code/GitHub/elijah/nix-home` resolves to the correct directory
- [ ] **Test Nix build**: Run `nix build .#darwinConfigurations.elw.system` to ensure configuration is valid
- [ ] **Test configuration switch**: Apply the new configuration and verify scripts and Warp workflows still work

**Recommended test plan:**
1. Build the configuration: `nix build .#darwinConfigurations.elw.system`
2. Switch to new configuration: `./result/sw/bin/darwin-rebuild switch --flake .#elw`
3. Verify symlinks exist: `ls -la ~/scripts ~/.warp`
4. Test that scripts and Warp workflows function correctly

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph "Home Manager Configuration"
        default["home/default.nix<br/>Imports assets.nix"]:::context
        assets["home/assets.nix<br/>CHANGED: nixConfigDirectory<br/>OLD: /Users/elw/Code/GitHub/elijah/nix-home<br/>NEW: ${config.home.homeDirectory}/Code/GitHub/elijah/nix-home"]:::major-edit
        scripts["~/scripts<br/>Symlink target"]:::context
        warp["~/.warp<br/>Symlink target"]:::context
    end
    
    subgraph "File System"
        repo["Code/GitHub/elijah/nix-home/<br/>Repository location"]:::context
        assets_dir["assets/scripts<br/>Source directory"]:::context
        warp_dir["assets/.warp<br/>Source directory"]:::context
    end
    
    default -->|imports| assets
    assets -->|"mkOutOfStoreSymlink"| scripts
    assets -->|"mkOutOfStoreSymlink"| warp
    assets -->|"nixConfigDirectory path"| repo
    repo --> assets_dir
    repo --> warp_dir
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- This change addresses the second highest priority issue from the efficiency analysis
- The dynamic path should work across macOS and WSL systems as intended by the original FIXME comment
- The symlink functionality depends on the repository being in the same relative location (`Code/GitHub/elijah/nix-home`) under the user's home directory
- **Session**: https://app.devin.ai/sessions/5f8296981a7947d69a0d716507dacfcb
- **Requested by**: Elijah Wright (@elijah)
